### PR TITLE
Pid

### DIFF
--- a/PizzaOvenControllerSketch/PizzaOvenControllerSketch.ino
+++ b/PizzaOvenControllerSketch/PizzaOvenControllerSketch.ino
@@ -63,7 +63,7 @@ static TcLimitCheck lrTcLimit(1000, 5000);
 //------------------------------------------
 #define FIRMWARE_MAJOR_VERSION   1
 #define FIRMWARE_MINOR_VERSION   3
-#define FIRMWARE_BUILD_VERSION   2
+#define FIRMWARE_BUILD_VERSION   3
 
 const char versionString[] = {'V', ' ', '0' + FIRMWARE_MAJOR_VERSION, '.', '0' + FIRMWARE_MINOR_VERSION, ' ', 'b', 'u', 'g', 'f', 'i', 'x', ' ', '0' + FIRMWARE_BUILD_VERSION, 0};
 
@@ -147,12 +147,11 @@ const uint16_t maxTempSetting[] = {MAX_UPPER_TEMP, MAX_UPPER_TEMP, MAX_LOWER_TEM
 #define PID_UR_KP 1.1
 #define PID_UR_KI 0.00129
 #define PID_UR_KD 0.0
-PidParameters pidGainsFront_Aggressive = {0.9, 0.02, 0.0};
+
+PidParameters pidGainsFront_Aggressive = {0.7, 0.019, 0.0};
 PidParameters pidGainsRear_Aggressive = {0.75, 0.02, 0.0};
-PidParameters pidGainsFront_Normal = {1.0, 0.00100, 0.0};
-PidParameters pidGainsRear_Normal = {1.0, 0.00100, 0.0};
-//PidIo upperFrontPidIo = {1000, 47, {0.9, 0.00113, 0.4}};
-//PidIo upperRearPidIo  = {1000, 47, {0.6, 0.00107, 0.4}};
+PidParameters pidGainsFront_Normal = {5.0, 0.00130, 0.0};
+PidParameters pidGainsRear_Normal = {5.0, 0.00150, 0.0};
 PidIo upperFrontPidIo = {1000, 47, {PID_UF_KP, PID_UF_KI, PID_UF_KD}};
 PidIo upperRearPidIo  = {1000, 47, {PID_UR_KP, PID_UR_KI, PID_UR_KD}};
 PID upperFrontPID(&upperFrontHeater.thermocouple, &upperFrontPidIo.Output, &upperFrontPidIo.Setpoint,
@@ -1450,7 +1449,7 @@ void loop()
   upperRearPidIo.Setpoint = (upperRearHeater.parameter.tempSetPointHighOff + upperRearHeater.parameter.tempSetPointLowOn) / 2;
 
   // set gains
-  if (fabs(upperFrontPidIo.Setpoint - upperFrontHeater.thermocouple) > PID_GAIN_SHIFT_TEMP_DIFF) {
+  if ((fabs(upperFrontPidIo.Setpoint - upperFrontHeater.thermocouple) > PID_GAIN_SHIFT_TEMP_DIFF) && (getCookingState() == cookingPreheat)) {
     // use normal gains
     upperFrontPID.SetTunings(pidGainsFront_Normal.kp, pidGainsFront_Normal.ki, pidGainsFront_Normal.kd);
   } else {
@@ -1458,7 +1457,7 @@ void loop()
     upperFrontPID.SetTunings(pidGainsFront_Aggressive.kp, pidGainsFront_Aggressive.ki, pidGainsFront_Aggressive.kd);
   }
 
-  if (fabs(upperRearPidIo.Setpoint - upperRearHeater.thermocouple) > PID_GAIN_SHIFT_TEMP_DIFF) {
+  if ((fabs(upperRearPidIo.Setpoint - upperRearHeater.thermocouple) > PID_GAIN_SHIFT_TEMP_DIFF) && (getCookingState() == cookingPreheat)) {
     // use normal gains
     upperRearPID.SetTunings(pidGainsRear_Normal.kp, pidGainsRear_Normal.ki, pidGainsRear_Normal.kd);
   } else {

--- a/PizzaOvenControllerSketch/PizzaOvenControllerSketch.ino
+++ b/PizzaOvenControllerSketch/PizzaOvenControllerSketch.ino
@@ -965,7 +965,6 @@ void setup()
   ConvertHeaterPercentCounts();
 
 #ifdef USE_PID
-  Serial.println(F("Setting tunings"));
   upperFrontPID.SetMode(MANUAL);
   upperFrontPID.SetOutputLimits(0, MAX_PID_OUTPUT);
   upperFrontPID.SetSampleTime(4000);

--- a/PizzaOvenControllerSketch/PizzaOvenControllerSketch.ino
+++ b/PizzaOvenControllerSketch/PizzaOvenControllerSketch.ino
@@ -140,8 +140,17 @@ const uint16_t maxTempSetting[] = {MAX_UPPER_TEMP, MAX_UPPER_TEMP, MAX_LOWER_TEM
 #ifdef USE_PID
 // PID stuff
 #define MAX_PID_OUTPUT 100
-PidIo upperFrontPidIo = {1000, 47, {5.863, 5.0, 0.0}};
-PidIo upperRearPidIo  = {1000, 47, {16.706, 10.0, 0.0}};
+// Define PID values here
+#define PID_UF_KP 1.1
+#define PID_UF_KI 0.00124
+#define PID_UF_KD 0.0
+#define PID_UR_KP 1.1
+#define PID_UR_KI 0.00129
+#define PID_UR_KD 0.0
+//PidIo upperFrontPidIo = {1000, 47, {0.9, 0.00113, 0.4}};
+//PidIo upperRearPidIo  = {1000, 47, {0.6, 0.00107, 0.4}};
+PidIo upperFrontPidIo = {1000, 47, {PID_UF_KP, PID_UF_KI, PID_UF_KD}};
+PidIo upperRearPidIo  = {1000, 47, {PID_UR_KP, PID_UR_KI, PID_UR_KD}};
 PID upperFrontPID(&upperFrontHeater.thermocouple, &upperFrontPidIo.Output, &upperFrontPidIo.Setpoint,
                   upperFrontPidIo.pidParameters.kp, upperFrontPidIo.pidParameters.ki, upperFrontPidIo.pidParameters.kd, DIRECT);
 PID upperRearPID(&upperRearHeater.thermocouple, &upperRearPidIo.Output, &upperRearPidIo.Setpoint,
@@ -680,18 +689,18 @@ void PeriodicOutputInfo()
     
 #ifdef USE_PID
 #ifdef ENABLE_PID_TUNING
-    case 2:
+    case 3:
       Serial.print(F("DEBUG, Time, UR KP, UR KI, UR KD, UR Raw, UR Temp, UR DC, UR Setpoint, UR pTerm, "));
       printPhase++;
       break;
-    case 3:
+    case 4:
       Serial.println(F("UR iTerm, UR dTerm, UF KP, UF KI, UF KD, UF Raw, UF Temp, UF DC, UF Setpoint, UF pTerm, UF iTerm, UF dTerm"));
       printPhase++;
       break;
-    case 4:
+    case 5:
       printPhase++;
       break;
-    case 5:
+    case 6:
       Serial.print(F("DEBUG, "));
       Serial.print(millis());
       Serial.print(F(", "));
@@ -703,7 +712,7 @@ void PeriodicOutputInfo()
       Serial.print(F(", "));
       printPhase++;
       break;
-    case 6:
+    case 7:
       Serial.print(readAD8495KTC(ANALOG_THERMO_UPPER_REAR));
       Serial.print(F(", "));
       Serial.print(upperRearHeater.thermocouple);
@@ -714,7 +723,7 @@ void PeriodicOutputInfo()
       Serial.print(F(", "));
       printPhase++;
       break;
-    case 7:
+    case 8:
       upperRearPID.GetTerms(&pTerm, &iTerm, &dTerm);
       Serial.print(pTerm, 6);
       Serial.print(F(", "));
@@ -724,7 +733,7 @@ void PeriodicOutputInfo()
       Serial.print(F(", "));
       printPhase++;
       break;
-    case 8:
+    case 9:
       Serial.print(upperFrontPID.GetKp(), 7);
       Serial.print(F(", "));
       Serial.print(upperFrontPID.GetKi(), 7);
@@ -733,7 +742,7 @@ void PeriodicOutputInfo()
       Serial.print(F(", "));
       printPhase++;
       break;
-    case 9:
+    case 10:
       Serial.print(readAD8495KTC(ANALOG_THERMO_UPPER_FRONT));
       Serial.print(F(", "));
       Serial.print(upperFrontHeater.thermocouple);
@@ -744,7 +753,7 @@ void PeriodicOutputInfo()
       Serial.print(F(", "));
       printPhase++;
       break;
-    case 10:
+    case 11:
       upperFrontPID.GetTerms(&pTerm, &iTerm, &dTerm);
       Serial.print(pTerm, 6);
       Serial.print(F(", "));
@@ -912,7 +921,7 @@ void setup()
 
   serialCommWrapperInit(sendSerialByte, handleIncomingMessage);
   handleIncomingMessage((uint8_t *)"v", 1);
-  
+
   pizzaMemoryInitResponse = pizzaMemoryInit();
 
   if (pizzaMemoryWasEmpty == pizzaMemoryInitResponse)
@@ -925,7 +934,7 @@ void setup()
     Serial.println(F("DEBUG Reading parameters from EEPROM memory."));
     readParametersFromMemory();
   }
-
+  
   acInputsInit();
 
   // Initialize Timer1
@@ -953,14 +962,21 @@ void setup()
   ConvertHeaterPercentCounts();
 
 #ifdef USE_PID
+  Serial.println(F("Setting tunings"));
   upperFrontPID.SetMode(MANUAL);
   upperFrontPID.SetOutputLimits(0, MAX_PID_OUTPUT);
   upperFrontPID.SetSampleTime(4000);
+  upperFrontPidIo.pidParameters.kp = PID_UF_KP;
+  upperFrontPidIo.pidParameters.ki = PID_UF_KI;
+  upperFrontPidIo.pidParameters.kd = PID_UF_KD;
   upperFrontPID.SetTunings(upperFrontPidIo.pidParameters.kp, upperFrontPidIo.pidParameters.ki, upperFrontPidIo.pidParameters.kd);
 
   upperRearPID.SetMode(MANUAL);
   upperRearPID.SetOutputLimits(0, MAX_PID_OUTPUT);
   upperRearPID.SetSampleTime(4000);
+  upperRearPidIo.pidParameters.kp = PID_UR_KP;
+  upperRearPidIo.pidParameters.ki = PID_UR_KI;
+  upperRearPidIo.pidParameters.kd = PID_UR_KD;
   upperRearPID.SetTunings(upperRearPidIo.pidParameters.kp, upperRearPidIo.pidParameters.ki, upperRearPidIo.pidParameters.kd);
 #endif
 
@@ -1436,4 +1452,3 @@ void loop()
 
 #endif
 }
-

--- a/PizzaOvenControllerSketch/config.h
+++ b/PizzaOvenControllerSketch/config.h
@@ -24,7 +24,7 @@
 #define CONFIG_H_
 
 #define USE_PID
-//#define ENABLE_PID_TUNING
+#define ENABLE_PID_TUNING
 
 #define COOL_DOWN_EXIT_TEMP    ((double)425.0)
 #define MAX_UPPER_TEMP (1300)

--- a/PizzaOvenControllerSketch/config.h
+++ b/PizzaOvenControllerSketch/config.h
@@ -24,7 +24,7 @@
 #define CONFIG_H_
 
 #define USE_PID
-#define ENABLE_PID_TUNING
+//#define ENABLE_PID_TUNING
 
 #define COOL_DOWN_EXIT_TEMP    ((double)425.0)
 #define MAX_UPPER_TEMP (1300)

--- a/PizzaOvenControllerSketch/cookingStateMachine.cpp
+++ b/PizzaOvenControllerSketch/cookingStateMachine.cpp
@@ -431,12 +431,13 @@ static void statePreheatUpdate()
     return;
   }
 
-  if ( upperFrontHeater.thermocouple >= (upperFrontHeater.parameter.tempSetPointHighOff + upperFrontHeater.parameter.tempSetPointLowOn)/2) 
+  #define PREHEAT_DONE_OFFSET 5.0
+  if ((upperFrontHeater.thermocouple + PREHEAT_DONE_OFFSET) >= (upperFrontHeater.parameter.tempSetPointHighOff + upperFrontHeater.parameter.tempSetPointLowOn)/2) 
   {
     upperFrontPreheated = true;
   }
 
-  if (  upperRearHeater.thermocouple >= (upperRearHeater.parameter.tempSetPointHighOff + upperRearHeater.parameter.tempSetPointLowOn)/2)
+  if ((upperRearHeater.thermocouple + PREHEAT_DONE_OFFSET) >= (upperRearHeater.parameter.tempSetPointHighOff + upperRearHeater.parameter.tempSetPointLowOn)/2)
   {
     upperRearPreheated = true;
   }

--- a/PizzaOvenControllerSketch/cookingStateMachine.cpp
+++ b/PizzaOvenControllerSketch/cookingStateMachine.cpp
@@ -640,6 +640,7 @@ static void stateCoolDownEnter()
   upperRearPidIo.Output = 0.0;
   pizzaOvenStartRequested = false;
   pizzaOvenStopRequested = false;
+  stoneIsPreheated = false;
 }
 
 static void stateCoolDownUpdate()
@@ -676,4 +677,3 @@ static void stateCoolDownExit()
   pizzaOvenStartRequested = false;
   pizzaOvenStopRequested = false;
 }
-

--- a/PizzaOvenControllerSketch/cookingStateMachine.cpp
+++ b/PizzaOvenControllerSketch/cookingStateMachine.cpp
@@ -353,13 +353,9 @@ static void statePreheatEnter()
   changeRelayState(HEATER_UPPER_REAR_DLB, relayStateOn);
   
   upperFrontPidIo.Output = getUFSeedValue(upperFrontHeater.thermocouple);
-  Serial.print(F("Seeding UF PID value to "));
-  Serial.println(upperFrontPidIo.Output);
   upperFrontPID.SetMode(AUTOMATIC);
   
   upperRearPidIo.Output = getURSeedValue(upperRearHeater.thermocouple);
-  Serial.print(F("Seeding UR PID value to "));
-  Serial.println(upperRearPidIo.Output);
   upperRearPID.SetMode(AUTOMATIC);
 
   upperFrontPreheated = false;


### PR DESCRIPTION
Changes:
- Final PID values
- Add new set of gains, normal gains used during preheat and a set used after preheat
- Latch upper preheat states independently
- Exit preheat of element is within 5F of setpoint
- Set PID to manual when not trying to heat the dome
- Set PID to auto when trying to heat the dome
- Bumped version for release