### PR TITLE
Add Catalyst Heater

### DIFF
--- a/PizzaOvenControllerSketch/globals.h
+++ b/PizzaOvenControllerSketch/globals.h
@@ -3,10 +3,13 @@
 #include "config.h"
 
 extern Heater upperFrontHeater;
-extern Heater  lowerFrontHeater;
+extern Heater lowerFrontHeater;
 #ifdef CONFIGURATION_ORIGINAL
 extern Heater upperRearHeater;
 extern Heater lowerRearHeater;
+#endif
+#ifdef CONFIGURATION_LOW_COST
+extern Heater catalystHeater; 
 #endif
 extern volatile uint32_t triacTimeBase;
 extern volatile uint32_t relayTimeBase;

--- a/PizzaOvenControllerSketch/pinDefinitions.h
+++ b/PizzaOvenControllerSketch/pinDefinitions.h
@@ -31,17 +31,17 @@
 // Original POMC
 ///////////////////////////////////////////////////////////////////////////////////////
 // Pin Definitions
-#define COOLING_FAN_RELAY         (12) // cooling fan relay
-#define COOLING_FAN_LOW_SPEED     ( 2) // cooling fan low speed relay PD2
+#define COOLING_FAN_RELAY          (12) // cooling fan relay
+#define COOLING_FAN_LOW_SPEED      ( 2) // cooling fan low speed relay PD2
 
-#define HEATER_UPPER_FRONT_DLB     (8) //Relay that provides L1 to the triac, must be ON for heat
-#define HEATER_TRIAC_UPPER_FRONT  (A0) // triac output
-#define HEATER_UPPER_REAR_DLB      ( 9) //Relay that provides L1 to the triac, must be ON for heat
-#define HEATER_TRIAC_UPPER_REAR   (A1) // triac output
+#define HEATER_UPPER_FRONT_DLB     ( 8) // Relay that provides L1 to the triac, must be ON for heat
+#define HEATER_TRIAC_UPPER_FRONT   (A0) // triac output
+#define HEATER_UPPER_REAR_DLB      ( 9) // Relay that provides L1 to the triac, must be ON for heat
+#define HEATER_TRIAC_UPPER_REAR    (A1) // triac output
 
 // Lower heater relays - These are cascaded.  Only turn on one at a time.
-#define HEATER_RELAY_LOWER_FRONT  (10) // relay output
-#define HEATER_RELAY_LOWER_REAR   (11) // relay output
+#define HEATER_RELAY_LOWER_FRONT   (10) // relay output
+#define HEATER_RELAY_LOWER_REAR    (11) // relay output
 
 // Other outputs
 #define BOOST_ENABLE               ( 7) //Enable 15V pull in voltage for relays
@@ -71,8 +71,8 @@
 #define COOLING_FAN_RELAY          (PIN_PC4) // cooling fan relay
 #define COOLING_FAN_LOW_SPEED      (PIN_PC6) // cooling fan low speed relay
 #define HEATER_TRIAC_UPPER_FRONT   (PIN_PC2) // triac output for the upper heaters
-#define HEATER_UPPER_FRONT_DLB     (PIN_PD5) // Relay that provides L1 to the triac, must be ON for heat
-#define HEATER_RELAY_LOWER_FRONT   (PIN_PC1) // relay output for the lower heaters
+#define HEATER_UPPER_FRONT_DLB     (PIN_PC1) // Relay that provides L1 to the triac, must be ON for heat
+#define HEATER_RELAY_LOWER_FRONT   (PIN_PD5) // relay output for the lower heaters
 
 // Other outputs
 #define BOOST_ENABLE               (PIN_PD4) //Enable 15V pull in voltage for relays

--- a/PizzaOvenControllerSketch/pinDefinitions.h
+++ b/PizzaOvenControllerSketch/pinDefinitions.h
@@ -79,7 +79,7 @@
 #define RELAY_WATCHDOG             (PIN_PD3) //Signal must toggle at a rate of X Hz in order to enable relays
 #define DOOR_LATCH_MOTOR_DRIVE_PIN (PIN_PC5)
 #define CATALYST_HEATER_TRIAC_PIN  (PIN_PC3) // triac out to drive the catalyst heater
-#define CATALYST_HEATER_RELAY_PIN  (PIN_PD6) // the relay is inseries with the triac and is a DLB
+#define CATALYST_HEATER_RELAY_PIN  (PIN_PD6) // the relay is in series with the triac and is a DLB
 #define VENT_OUTPUT_PIN            (PIN_PA6) // relay to drive the motorized vent
 
 // Digital inputs

--- a/PizzaOvenControllerSketch/pinDefinitions.h
+++ b/PizzaOvenControllerSketch/pinDefinitions.h
@@ -71,8 +71,8 @@
 #define COOLING_FAN_RELAY          (PIN_PC4) // cooling fan relay
 #define COOLING_FAN_LOW_SPEED      (PIN_PC6) // cooling fan low speed relay
 #define HEATER_TRIAC_UPPER_FRONT   (PIN_PC2) // triac output for the upper heaters
-#define HEATER_UPPER_FRONT_DLB     (PIN_PC1) // Relay that provides L1 to the triac, must be ON for heat
-#define HEATER_RELAY_LOWER_FRONT   (PIN_PD5) // relay output for the lower heaters
+#define HEATER_UPPER_FRONT_DLB     (PIN_PD5) // Relay that provides L1 to the triac, must be ON for heat
+#define HEATER_RELAY_LOWER_FRONT   (PIN_PC1) // relay output for the lower heaters
 
 // Other outputs
 #define BOOST_ENABLE               (PIN_PD4) //Enable 15V pull in voltage for relays

--- a/PizzaOvenControllerSketch/pizzaMemory.h
+++ b/PizzaOvenControllerSketch/pizzaMemory.h
@@ -33,6 +33,7 @@ typedef struct MemoryStore
   HeaterParameters upperRearHeaterParameters;
   HeaterParameters lowerFrontHeaterParameters;
   HeaterParameters lowerRearHeaterParameters;
+  HeaterParameters catalystHeaterParameters;
   uint16_t triacPeriodSeconds;
   uint16_t relayPeriodSeconds;
   PidParameters upperFrontPidParameters;


### PR DESCRIPTION
Add the Catalyst Heater to be controlled such that it is on 100% for upper heater dome set points between 700F and 900F. The duty cycle of the catalyst heater should decline linearly for setpionts between 900F and 1200F. For example: Setpoint of 1050 would have a 50% duty cycle. The period for the duty cycle is 4 seconds. 
![image](https://user-images.githubusercontent.com/10553845/120491560-56d91280-c387-11eb-89db-53ec9bc9ce43.png)

Changes to the heater relays are no longer in scope due to wiring changes to fix the issue.
